### PR TITLE
Fix formatting of post content when created in the app

### DIFF
--- a/screens/PostUpdate.js
+++ b/screens/PostUpdate.js
@@ -31,7 +31,7 @@ export default withTheme(function PostUpdate({ navigation, theme }) {
       const res = await api.createPost({
         title,
         summary,
-        content,
+        content: "<p>" + content.replace(/\n/g, "<br/>") + "</p>",
         tags: tags.map((t) => t.name),
       });
 


### PR DESCRIPTION
So because the post content is rendered in a webview, it's obviously treated as html. This means that input such as
```
Line 1

Line 2
```
will end up rendered as
```
Line 1 Line 2
```
if it's created in the app, rather than the web editor which generates html.

To fix this, I've basically made it pre-process the text to replace `\n` with `<br/>`.

Also, the web editor generates each paragraph inside `<p>` tags, which adds some spacing to the top of the paragraph, causing another difference in rendering between plain text and rich text. To fix this, I've just wrapped the whole text in `<p>` tags.

If you can think of any problems this would cause or a better solution, I'm all ears!